### PR TITLE
Fix setup script, worlds and plugin bug

### DIFF
--- a/egg-cuberite-survival.json
+++ b/egg-cuberite-survival.json
@@ -9,14 +9,14 @@
     "image": "quay.io\/parkervcp\/pterodactyl-images:base_debian",
     "startup": ".\/Cuberite",
     "config": {
-        "files": "{\r\n    \"settings.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"Server.Ports\": \"{{server.build.default.port}}\",\r\n            \"Server.Description\": \"{{server.build.env.SERV_DESC}}\",\r\n            \"Authenticate\": 0,\r\n            \"AllowBungeeCord\": 1\r\n        }\r\n    },\r\n    \"webadmin.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"User:admin.Password\": \"{{server.build.env.ADMIN_PASS}}\",\r\n            \"WebAdmin.Ports\": \"{{server.build.env.WEB_PORT}}\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"webadmin.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"User:admin.Password\": \"{{server.build.env.ADMIN_PASS}}\",\r\n            \"WebAdmin.Ports\": \"{{server.build.env.WEB_PORT}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Startup complete\"\r\n}",
         "logs": "{}",
         "stop": "stop"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\napt update\r\napt install -y git\r\n\r\ncd \/mnt\/server\r\n\r\nrm -rf server-survival-egg\r\ngit clone https:\/\/github.com\/equitas-mc\/server-survival-egg.git\r\ncd server-survival-egg\r\n./setup.sh",
+            "script": "#!\/bin\/bash\r\n\r\napt update\r\napt install -y git\r\n\r\ncd \/mnt\/server\r\n\r\nrm -rf server-egg\r\ngit clone https:\/\/github.com\/equitas-mc\/server-survival-egg.git server-egg\r\n./server-egg/setup.sh",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }

--- a/settings.ini
+++ b/settings.ini
@@ -1,6 +1,3 @@
-; This is the main server configuration
-; Most of the settings here can be configured using the webadmin interface, if enabled in webadmin.ini
-
 [Folders]
 ProtocolPalettes=Protocol
 
@@ -17,12 +14,12 @@ UUIDToProfileServer=sessionserver.mojang.com
 UUIDToProfileAddress=/session/minecraft/profile/%UUID%?unsigned=false
 
 [Server]
-Description=Cuberite - in C++!
+Description=Equitas cuberite survival server
 ShutdownMessage=Server shutdown
 MaxPlayers=100
 HardcoreEnabled=0
 AllowMultiLogin=0
-Ports=25565
+Ports=25601
 AllowMultiWorldTabCompletion=1
 DefaultViewDistance=10
 
@@ -38,6 +35,8 @@ LoadNamedPlayerData=1
 
 [Worlds]
 DefaultWorld=world
+World=world_nether
+World=world_the_end
 
 [WorldPaths]
 world=world

--- a/setup.sh
+++ b/setup.sh
@@ -2,11 +2,10 @@
 
 apt update
 apt install -y wget
-cd /mnt/server
 
 rm Cuberite.tar.gz
 wget https://builds.cuberite.org/job/Cuberite%20Linux%20x64%20Master/lastSuccessfulBuild/artifact/Cuberite.tar.gz
 tar -xf Cuberite.tar.gz
 
-cp /mnt/server/server-skyblock-egg/settings.ini .
-cp /mnt/server/server-skyblock-egg/webadmin.ini .
+cp server-egg/settings.ini .
+cp server-egg/webadmin.ini .

--- a/webadmin.ini
+++ b/webadmin.ini
@@ -7,5 +7,5 @@
 ; Please restart Cuberite to apply changes made in this file!
 
 [WebAdmin]
-Ports=8080
+Ports=26601
 Enabled=1


### PR DESCRIPTION
Fix errors in the setup script.

cuberite stores multiple values with the same key in the `settings.ini`.
pterodactyl's ini parser does not allow this and takes only the last (?)
and removes the other entries.

The easy fix is to not edit the `settings.ini` and have the correct
values in the template.
This could run into problems if same servers on different node use a
different port.